### PR TITLE
[bug] getUrlParameter always returns a string

### DIFF
--- a/lib/src/util/url-utils.js
+++ b/lib/src/util/url-utils.js
@@ -40,6 +40,6 @@ exports.parseHeaderForLinks = function (header) {
  */
 exports.getUrlParameter = function (name, search) {
     var url = new URL("http://localhost" + search); // using a dummy url for parsing
-    return url.searchParams.get(name);
+    return url.searchParams.get(name) || '';
 };
 //# sourceMappingURL=url-utils.js.map

--- a/src/util/url-utils.ts
+++ b/src/util/url-utils.ts
@@ -48,5 +48,5 @@ export const parseHeaderForLinks = (header: string): any => {
  */
 export const getUrlParameter = (name: string, search: string): string => {
   const url = new URL(`http://localhost${search}`); // using a dummy url for parsing
-  return url.searchParams.get(name);
+  return url.searchParams.get(name) || '';
 };

--- a/tests/spec/util/url-utils.spec.ts
+++ b/tests/spec/util/url-utils.spec.ts
@@ -30,4 +30,8 @@ describe('getUrlParameter', () => {
     expect(getUrlParameter('key', '?test=1245&key=123hghygh1225&test2=55558')).to.eql('123hghygh1225');
     expect(getUrlParameter('key', '?test=1245&key=123hghyg+h1225&test2=55558')).to.eql('123hghyg h1225');
   });
+
+  it('should return an empty string for missing name', () => {
+    expect(getUrlParameter('test', '?')).to.eql('');
+  });
 });


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/get, `searchParams.get` returns `null` if it can't find the search parameter. This was breaking `getSortState` when `sort` was not in the search string.