### PR TITLE
Make TextFormat locale-aware

### DIFF
--- a/src/formatter/text-format.tsx
+++ b/src/formatter/text-format.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import * as numeral from 'numeral';
 import * as moment from 'moment';
+import TranslatorContext from '../language/translator-context';
 
 export type ITextFormatTypes = 'date' | 'number';
 
@@ -9,6 +10,7 @@ export interface ITextFormatProps {
   type: ITextFormatTypes;
   format?: string;
   blankOnInvalid?: boolean;
+  locale?: string;
 }
 
 /**
@@ -19,14 +21,27 @@ export interface ITextFormatProps {
  *    For date type momentJs(http://momentjs.com/docs/#/displaying) format is used
  *    For number type NumeralJS (http://numeraljs.com/#format) format is used
  * @param blankOnInvalid optional to output error or blank on null/invalid values
+ * @param locale optional locale in which to format value
  */
-export const TextFormat = ({ value, type, format, blankOnInvalid }: ITextFormatProps) => {
+export const TextFormat = ({ value, type, format, blankOnInvalid, locale }: ITextFormatProps) => {
   if (blankOnInvalid) {
     if (!value || !type) return null;
   }
 
+  if (!locale) {
+    // TODO: find a better way to keep track of *current* locale
+    locale = TranslatorContext.context.locale;
+    numeral.locale(locale);
+  }
+
   if (type === 'date') {
-    return <span>{moment(value).format(format)}</span>;
+    return (
+      <span>
+        {moment(value)
+          .locale(locale)
+          .format(format)}
+      </span>
+    );
   } else if (type === 'number') {
     return <span>{(numeral(value) as any).format(format)}</span>;
   }

--- a/src/formatter/text-format.tsx
+++ b/src/formatter/text-format.tsx
@@ -21,7 +21,7 @@ export interface ITextFormatProps {
  *    For date type momentJs(http://momentjs.com/docs/#/displaying) format is used
  *    For number type NumeralJS (http://numeraljs.com/#format) format is used
  * @param blankOnInvalid optional to output error or blank on null/invalid values
- * @param locale optional locale in which to format value
+ * @param locale optional locale in which to format value or current locale from TranslatorContext
  */
 export const TextFormat = ({ value, type, format, blankOnInvalid, locale }: ITextFormatProps) => {
   if (blankOnInvalid) {

--- a/src/language/translator-context.ts
+++ b/src/language/translator-context.ts
@@ -1,5 +1,5 @@
 /**
- * Holder for tranlation content and locale
+ * Holder for translation content and locale
  */
 
 class TranslatorContext {

--- a/tests/spec/formatter/text-format.spec.tsx
+++ b/tests/spec/formatter/text-format.spec.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import * as moment from 'moment';
 import { mount } from 'enzyme';
 import { expect } from 'chai';
+import * as numeral from 'numeral';
+require('numeral/locales'); // load numeral-js locale data
 
 import { TextFormat } from '../../../react-jhipster';
 
@@ -30,6 +32,24 @@ describe('text-format component', () => {
       expect(node.length).to.eql(1);
       expect(node.text()).to.eql(moment(d).format('DD MM YY'));
     });
+    describe('using locales and formats', () => {
+      const locales = ['en', 'it', 'de', 'fr', 'sk', 'tr', 'vi']; // a sample of locales
+      const formats = ['ddd', 'dddd', 'MMM', 'MMMM']; // short and long textual formats of days and months
+      locales.forEach(locale => {
+        formats.forEach(format => {
+          it(`Should return a valid date formatted with format '${format}' in '${locale}'`, () => {
+            const d = new Date();
+            const node = mount(<TextFormat value={d} type="date" format={format} locale={locale} />);
+            expect(node.length).to.eql(1);
+            expect(node.text()).to.eql(
+              moment(d)
+                .locale(locale)
+                .format(format)
+            );
+          });
+        });
+      });
+    });
   });
   describe('number format', () => {
     it('Should return 0 in text when value is invalid', () => {
@@ -53,6 +73,22 @@ describe('text-format component', () => {
       const node = mount(<TextFormat value={n} type="number" format="0,0.00" />);
       expect(node.length).to.eql(1);
       expect(node.text()).to.eql(moment(n).format('100,000.12'));
+    });
+    // a sample of locales
+    ['en', 'it', 'de', 'fr', 'sk', 'tr', 'vi'].forEach(locale => {
+      describe(`using locale: '${locale}'`, () => {
+        before(() => numeral.locale(locale));
+
+        // currency and ordinal textual formats
+        ['$0,0.00', '$ 0,0[.]00'].forEach(format => {
+          it(`Should return a number formatted with format '${format}' in '${locale}'`, () => {
+            const n = 100000.1234;
+            const node = mount(<TextFormat value={n} type="number" format={format} locale={locale} />);
+            expect(node.length).to.eql(1);
+            expect(node.text()).to.eql(numeral(n).format(format));
+          });
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
Allows providing a locale prop to TextFormat, resolves #42 