### PR TITLE
FIX: translations for falsy values : empty, 0 and false

### DIFF
--- a/src/language/translate.tsx
+++ b/src/language/translate.tsx
@@ -39,6 +39,8 @@ const normalizeValue = (value, key) => {
   }
 };
 
+const isNullOrUndefined = (value: any) => value == null;
+
 /**
  * Adapted from https://github.com/bloodyowl/react-translate
  * licenced under The MIT License (MIT) Copyright (c) 2014 Matthias Le Brun
@@ -152,8 +154,11 @@ const doTranslate = (key, interpolate, children) => {
   }
 
   const preRender = data ? get(data, key) || deepFindDirty(data, key) : null;
-  const preSanitize = render(preRender, interpolate) || showMissingOrDefault(key, children);
-  if (/<[a-z][\s\S]*>/i.test(preSanitize)) {
+  const renderedValue = render(preRender, interpolate);
+
+  const preSanitize = !isNullOrUndefined(renderedValue) ? renderedValue : showMissingOrDefault(key, children);
+
+  if (preSanitize === false || /<[a-z][\s\S]*>/i.test(preSanitize)) {
     // String contains HTML tags. Allow only a super restricted set of tags and attributes
     const content = sanitizeHtml(preSanitize, {
       allowedTags: ['b', 'i', 'em', 'strong', 'a', 'br', 'hr'],

--- a/src/language/translate.tsx
+++ b/src/language/translate.tsx
@@ -39,7 +39,7 @@ const normalizeValue = (value, key) => {
   }
 };
 
-const isNullOrUndefined = (value: any) => value == null;
+const isNullOrUndefined = (value: any) => value === null || value === undefined;
 
 /**
  * Adapted from https://github.com/bloodyowl/react-translate

--- a/tests/spec/language/translate.spec.tsx
+++ b/tests/spec/language/translate.spec.tsx
@@ -33,6 +33,11 @@ describe('Translate', () => {
             'bar8.bar9': {
               'bar10.bar11': 'bar7891011'
             }
+          },
+          barfalsy: {
+            'empty': '',
+            'zero': 0,
+            'false': false,
           }
         }
       });
@@ -114,28 +119,28 @@ describe('Translate', () => {
       expect(span.html()).to.equal('<span>bar7891011</span>');
       expect(span.text()).to.equal('bar7891011');
     });
-    it('renders a provided componenet with translated content', () => {
+    it('renders a provided component with translated content', () => {
       const mountedWrapper = mount(<Translate contentKey="foo.bar" component="h1" />);
       const span = mountedWrapper.find('h1');
       expect(span.length).to.equal(1);
       expect(span.html()).to.equal('<h1>i18n text</h1>');
       expect(span.text()).to.equal('i18n text');
     });
-    it('renders a provided componenet with translated & interpolated content', () => {
+    it('renders a provided component with translated & interpolated content', () => {
       const mountedWrapper = mount(<Translate contentKey="foo.fooz" component="h1" interpolate={{ foo: 'FOO', bar: 'BAR' }} />);
       const span = mountedWrapper.find('h1');
       expect(span.length).to.equal(1);
       expect(span.html()).to.equal('<h1>text FOO this BAR</h1>');
       expect(span.text()).to.equal('text FOO this BAR');
     });
-    it('renders a provided componenet with translated & interpolated content with html', () => {
+    it('renders a provided component with translated & interpolated content with html', () => {
       const mountedWrapper = mount(<Translate contentKey="foo.foofoo" component="h1" interpolate={{ foo: 'FOO', bar: 'BAR' }} />);
       const span = mountedWrapper.find('h1');
       expect(span.length).to.equal(1);
       expect(span.html()).to.equal('<h1>text FOO this BAR <b>test</b></h1>');
       expect(span.text()).to.equal('text FOO this BAR test');
     });
-    it('renders a provided componenet with translated, sanitized & interpolated content', () => {
+    it('renders a provided component with translated, sanitized & interpolated content', () => {
       const mountedWrapper = mount(<Translate contentKey="foo.foodirty" component="h1" interpolate={{ foo: 'FOO', bar: 'BAR' }} />);
       const span = mountedWrapper.find('h1');
       expect(span.length).to.equal(1);
@@ -149,6 +154,30 @@ describe('Translate', () => {
       expect(span.length).to.equal(1);
       expect(span.html()).to.equal('<span>i18n text fr</span>');
       expect(span.text()).to.equal('i18n text fr');
+    });
+
+    it('renders a default span with translated content for empty string', () => {
+      const mountedWrapper = mount(<Translate contentKey="foo.barfalsy.empty" />);
+      const span = mountedWrapper.find('span');
+      expect(span.length).to.equal(1);
+      expect(span.html()).to.equal('<span></span>');
+      expect(span.text()).to.equal('');
+    });
+
+    it('renders a default span with translated content for number 0', () => {
+      const mountedWrapper = mount(<Translate contentKey="foo.barfalsy.zero" />);
+      const span = mountedWrapper.find('span');
+      expect(span.length).to.equal(1);
+      expect(span.html()).to.equal('<span>0</span>');
+      expect(span.text()).to.equal('0');
+    });
+
+    it('renders a default span with translated content for boolean false', () => {
+      const mountedWrapper = mount(<Translate contentKey="foo.barfalsy.false" />);
+      const span = mountedWrapper.find('span');
+      expect(span.length).to.equal(1);
+      expect(span.html()).to.equal('<span>false</span>');
+      expect(span.text()).to.equal('false');
     });
   });
 });


### PR DESCRIPTION
Fix issue : https://github.com/jhipster/react-jhipster/issues/45

Below is how the values are translated depending on the frameworks.
It is now similar to angular translations.

|  value | vue | angular | react (before) | react fix |
|---|---|---|---|---| 
| ""  |  nothing is displayed | nothing is displayed  | translation-not-found | nothing is displayed |
| 0  |  key is displayed | 0  | translation-not-found | 0 |
| false | key is displayed | false | translation-not-found | false |
