### PR TITLE
fix: use dayjs

### DIFF
--- a/lib/src/formatter/text-format.js
+++ b/lib/src/formatter/text-format.js
@@ -3,7 +3,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.TextFormat = void 0;
 var React = require("react");
 var numeral = require("numeral");
-var moment = require("moment");
+var dayjs = require("dayjs");
 var translator_context_1 = require("../language/translator-context");
 require("numeral/locales");
 /**
@@ -11,7 +11,7 @@ require("numeral/locales");
  * @param value value to be formatted
  * @param type type of formatting to use ${ITextFormatTypes}
  * @param format optional format to use.
- *    For date type momentJs(http://momentjs.com/docs/#/displaying) format is used
+ *    For date type dayjs(https://day.js.org/docs/en/display/format) format is used
  *    For number type NumeralJS (http://numeraljs.com/#format) format is used
  * @param blankOnInvalid optional to output error or blank on null/invalid values
  * @param locale optional locale in which to format value or current locale from TranslatorContext
@@ -27,10 +27,15 @@ exports.TextFormat = function (_a) {
         locale = translator_context_1.default.context.locale;
         numeral.locale(locale);
     }
+    else {
+        require('dayjs/locale/' + locale);
+    }
     if (type === 'date') {
-        return (React.createElement("span", null, moment(value)
-            .locale(locale)
-            .format(format)));
+        return (React.createElement("span", null, locale
+            ? dayjs(value)
+                .locale(locale)
+                .format(format)
+            : dayjs(value).format(format)));
     }
     else if (type === 'number') {
         return React.createElement("span", null, numeral(value).format(format));

--- a/lib/src/language/translator-context.js
+++ b/lib/src/language/translator-context.js
@@ -33,6 +33,7 @@ var TranslatorContext = /** @class */ (function () {
     TranslatorContext.setLocale = function (locale) {
         this.context.previousLocale = this.context.locale;
         this.context.locale = locale || this.context.defaultLocale;
+        require('dayjs/locale/' + this.context.locale);
     };
     TranslatorContext.context = {
         previousLocale: null,

--- a/package-lock.json
+++ b/package-lock.json
@@ -2835,6 +2835,12 @@
         }
       }
     },
+    "dayjs": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.9.4.tgz",
+      "integrity": "sha512-ABSF3alrldf7nM9sQ2U+Ln67NRwmzlLOqG7kK03kck0mw3wlSSEKv/XhKGGxUjQcS57QeiCyNdrFgtj9nWlrng==",
+      "dev": true
+    },
     "debug": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
@@ -8710,7 +8716,8 @@
     "moment": {
       "version": "2.29.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
+      "dev": true
     },
     "moo": {
       "version": "0.5.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "homepage": "https://www.jhipster.tech",
   "peerDependencies": {
     "axios": "^0.18.0",
+    "dayjs": "^1.9.4",
     "react": "^16.8.5",
     "react-transition-group": "2.7.0",
     "react-dom": "^16.8.5",
@@ -40,7 +41,6 @@
   },
   "dependencies": {
     "lodash.get": "4.4.2",
-    "moment": "^2.24.0",
     "numeral": "2.0.6",
     "sanitize-html": "2.1.0"
   },
@@ -64,6 +64,7 @@
     "copy-webpack-plugin": "4.5.1",
     "cross-env": "5.1.4",
     "css-loader": "^2.1.1",
+    "dayjs": "^1.9.4",
     "enzyme": "3.9.0",
     "enzyme-adapter-react-16": "1.13.0",
     "eslint": "^6.1.0",

--- a/src/formatter/text-format.tsx
+++ b/src/formatter/text-format.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import * as numeral from 'numeral';
-import * as moment from 'moment';
+import * as dayjs from 'dayjs';
 import TranslatorContext from '../language/translator-context';
 import 'numeral/locales';
 
 export type ITextFormatTypes = 'date' | 'number';
 
 export interface ITextFormatProps {
-  value: string | number | Date | moment.Moment;
+  value: string | number | Date;
   type: ITextFormatTypes;
   format?: string;
   blankOnInvalid?: boolean;
@@ -19,7 +19,7 @@ export interface ITextFormatProps {
  * @param value value to be formatted
  * @param type type of formatting to use ${ITextFormatTypes}
  * @param format optional format to use.
- *    For date type momentJs(http://momentjs.com/docs/#/displaying) format is used
+ *    For date type dayjs(https://day.js.org/docs/en/display/format) format is used
  *    For number type NumeralJS (http://numeraljs.com/#format) format is used
  * @param blankOnInvalid optional to output error or blank on null/invalid values
  * @param locale optional locale in which to format value or current locale from TranslatorContext
@@ -33,13 +33,18 @@ export const TextFormat = ({ value, type, format, blankOnInvalid, locale }: ITex
     // TODO: find a better way to keep track of *current* locale
     locale = TranslatorContext.context.locale;
     numeral.locale(locale);
+  } else {
+    require('dayjs/locale/' + locale);
   }
+
   if (type === 'date') {
     return (
       <span>
-        {moment(value)
-          .locale(locale)
-          .format(format)}
+        {locale
+          ? dayjs(value)
+              .locale(locale)
+              .format(format)
+          : dayjs(value).format(format)}
       </span>
     );
   } else if (type === 'number') {

--- a/src/language/translator-context.ts
+++ b/src/language/translator-context.ts
@@ -31,6 +31,7 @@ class TranslatorContext {
   static setLocale(locale: string) {
     this.context.previousLocale = this.context.locale;
     this.context.locale = locale || this.context.defaultLocale;
+    require('dayjs/locale/' + this.context.locale);
   }
 }
 

--- a/tests/spec/formatter/text-format.spec.tsx
+++ b/tests/spec/formatter/text-format.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as moment from 'moment';
+import * as dayjs from 'dayjs';
 import { mount } from 'enzyme';
 import { expect } from 'chai';
 import * as numeral from 'numeral';
@@ -10,10 +10,10 @@ import { TextFormat } from '../../../react-jhipster';
 describe('text-format component', () => {
   // All tests will go here
   describe('date format', () => {
-    it('Should return Invalid date in text when value is invalid', () => {
+    it('Should return Invalid Date in text when value is invalid', () => {
       const node = mount(<TextFormat value={null} type="date" />);
       expect(node.length).to.eql(1);
-      expect(node.text()).to.eql('Invalid date');
+      expect(node.text()).to.eql('Invalid Date');
     });
     it('Should return blank when value is invalid and blankOnInvalid is true', () => {
       const node = mount(<TextFormat value={null} type="date" blankOnInvalid />);
@@ -24,13 +24,13 @@ describe('text-format component', () => {
       const d = new Date();
       const node = mount(<TextFormat value={d} type="date" />);
       expect(node.length).to.eql(1);
-      expect(node.text()).to.eql(moment(d).format());
+      expect(node.text()).to.eql(dayjs(d).format());
     });
     it('Should return formatted date for valid date and format', () => {
       const d = new Date();
       const node = mount(<TextFormat value={d} type="date" format="DD MM YY" />);
       expect(node.length).to.eql(1);
-      expect(node.text()).to.eql(moment(d).format('DD MM YY'));
+      expect(node.text()).to.eql(dayjs(d).format('DD MM YY'));
     });
     describe('using locales and formats', () => {
       const locales = ['en', 'it', 'de', 'fr', 'sk', 'tr', 'vi']; // a sample of locales
@@ -42,7 +42,7 @@ describe('text-format component', () => {
             const node = mount(<TextFormat value={d} type="date" format={format} locale={locale} />);
             expect(node.length).to.eql(1);
             expect(node.text()).to.eql(
-              moment(d)
+              dayjs(d)
                 .locale(locale)
                 .format(format)
             );
@@ -72,7 +72,7 @@ describe('text-format component', () => {
       const n = 100000.1234;
       const node = mount(<TextFormat value={n} type="number" format="0,0.00" />);
       expect(node.length).to.eql(1);
-      expect(node.text()).to.eql(moment(n).format('100,000.12'));
+      expect(node.text()).to.eql('100,000.12');
     });
     // a sample of locales
     ['en', 'it', 'de', 'fr', 'sk', 'tr', 'vi'].forEach(locale => {


### PR DESCRIPTION
Use dayjs (migration from momentjs)
fix https://github.com/jhipster/generator-jhipster/issues/12858

I suggest to use dayjs as a peer dependency. This way the main project will drive the unique version to use. (Does it work exactly like this ?, I am not an expert on this)


