### PR TITLE
Fix translation issue where an interpolation param contains a ReactEl…

### DIFF
--- a/src/language/translate.tsx
+++ b/src/language/translate.tsx
@@ -160,12 +160,15 @@ const doTranslate = (key, interpolate, children) => {
 
   if (preSanitize === false || /<[a-z][\s\S]*>/i.test(preSanitize)) {
     // String contains HTML tags. Allow only a super restricted set of tags and attributes
-    const content = sanitizeHtml(preSanitize, {
-      allowedTags: ['b', 'i', 'em', 'strong', 'a', 'br', 'hr'],
-      allowedAttributes: {
-        a: ['href', 'target'],
-      },
-    });
+    const preSanitizeArray = Array.isArray(preSanitize) ? preSanitize : [preSanitize];
+    const content = preSanitizeArray.map(part => part.$$typeof === REACT_ELEMENT ? part :
+      sanitizeHtml(part, {
+        allowedTags: ['b', 'i', 'em', 'strong', 'a', 'br', 'hr'],
+        allowedAttributes: {
+          a: ['href', 'target'],
+        },
+      }));
+
     return {
       content,
       html: true,
@@ -212,7 +215,8 @@ export const translate = (contentKey: string, interpolate?: any, children?: stri
   const translation = doTranslate(contentKey, interpolate, children);
 
   if (translation.html) {
-    return React.createElement('span', { dangerouslySetInnerHTML: { __html: translation.content } });
+    const contentArray = Array.isArray(translation.content) ? translation.content : [translation.content];
+    return contentArray.map(content => content.$$typeof === REACT_ELEMENT ? content : React.createElement('span', { dangerouslySetInnerHTML: { __html: content } }));
   } else {
     return translation.content;
   }


### PR DESCRIPTION
This pull request fixes an issue with the translation where a param that is a ReactElement is interpolated into a translation string containing HTML.

**language.json**
`{ "sample": { "title": "This demonstrates the <br /> {{ issue }}" } }`

**component.tsx**
`translate('sample.title', { issue: <div>Will not be shown</div> })`

**result**
This demonstrates the
 [object Object]

If the translation string does not contain html (`<br />`) the interpolation of the `div` param works.

