### PR TITLE
Improve typing of text-format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
       },
       "devDependencies": {
         "@testing-library/react": "^16.1.0",
+        "@types/numeral": "^2.0.5",
         "@types/react": "^18.3.14",
         "@types/react-dom": "^18.3.2",
         "@types/sanitize-html": "^2.13.0",
@@ -1565,6 +1566,13 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
       "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/numeral": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/numeral/-/numeral-2.0.5.tgz",
+      "integrity": "sha512-kH8I7OSSwQu9DS9JYdFWbuvhVzvFRoCPCkGxNwoGgaPeDfEPJlcxNvEOypZhQ3XXHsGbfIuYcxcJxKUfJHnRfw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
   },
   "devDependencies": {
     "@testing-library/react": "^16.1.0",
+    "@types/numeral": "^2.0.5",
     "@types/react": "^18.3.14",
     "@types/react-dom": "^18.3.2",
     "@types/sanitize-html": "^2.13.0",

--- a/src/formatter/text-format.tsx
+++ b/src/formatter/text-format.tsx
@@ -29,7 +29,7 @@ interface CommonTextFormatProps {
 }
 
 interface ITextFormatDateProps extends CommonTextFormatProps {
-  value: Date | Dayjs;
+  value: dayjs.ConfigType;
   type: 'date';
 }
 

--- a/src/formatter/text-format.tsx
+++ b/src/formatter/text-format.tsx
@@ -18,24 +18,32 @@
  */
 import React from 'react';
 import numeral from 'numeral';
-import dayjs from 'dayjs';
+import dayjs, { Dayjs } from 'dayjs';
 import TranslatorContext from '../language/translator-context';
 import 'numeral/locales';
 
-export type ITextFormatTypes = 'date' | 'number';
-
-export interface ITextFormatProps {
-  value: string | number | Date;
-  type: ITextFormatTypes;
+interface CommonTextFormatProps {
   format?: string;
   blankOnInvalid?: boolean;
   locale?: string;
 }
 
+interface ITextFormatDateProps extends CommonTextFormatProps {
+  value: Date | Dayjs;
+  type: 'date';
+}
+
+interface ITextFormatNumberProps extends CommonTextFormatProps {
+  value: number | string;
+  type: 'number';
+}
+
+export type ITextFormatProps = ITextFormatDateProps | ITextFormatNumberProps;
+
 /**
  * Formats the given value to specified type like date or number.
  * @param value value to be formatted
- * @param type type of formatting to use ${ITextFormatTypes}
+ * @param type type of formatting to use (`date` or `number`)
  * @param format optional format to use.
  *    For date type dayjs(https://day.js.org/docs/en/display/format) format is used
  *    For number type NumeralJS (http://numeraljs.com/#format) format is used


### PR DESCRIPTION
Slightly improves the typing of the `TextFormat` component so that the allowed value types depend on the `type` field:
when `type: "number"`, only `string | number` is allowed, and when `type: "date"`, any `dayjs.ConfigType` is allowed (`string | number | Date | Dayjs`)

This improves type safety, preventing common errors but also allowing the `Dayjs` type to be passed as an argument, which previously created a type error