### PR TITLE
Publish react-jhipster with npm trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,30 @@
+# This workflow publishes react-jhipster with npm trusted publishing.
+# Trusted publishing uses GitHub Actions OIDC and creates provenance automatically.
+
+name: Publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    if: github.repository == 'jhipster/react-jhipster'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Use Node.js 24
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+      - run: npm ci
+      - run: npm run build --if-present
+      - run: npm test
+      - run: npm publish

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "prepare": "npm run build && husky",
     "prettier:check": "prettier --check \"*.ts\" package.json \"{src,test}/**/*.{ts,tsx}\"",
     "prettier:format": "prettier --write \"*.ts\" package.json \"{src,test}/**/*.{ts,tsx}\"",
-    "release": "npm test && git push && git push --tags && npm publish",
+    "release": "npm test && git push && git push --tags",
     "release:major": "npm run build && npm run commit-lib && npm version major -a -m \"Update to %s\" && npm run release",
     "release:minor": "npm run build && npm run commit-lib && npm version minor -a -m \"Update to %s\" && npm run release",
     "release:patch": "npm run build && npm run commit-lib && npm version patch -a -m \"Update to %s\" && npm run release",


### PR DESCRIPTION
## Summary
- add a tag-triggered GitHub Actions publish workflow for v* releases
- use npm trusted publishing with GitHub OIDC so npm creates provenance automatically
- remove local npm publish from the release script so tag pushes hand publishing to Actions

Fixes jhipster/generator-jhipster#33522

## Validation
- npm test (Node 24.16.0, LF worktree): 135 tests passed; lint reported existing warnings only
- npm pack --dry-run
- npm exec -- prettier --check .github/workflows/publish.yml package.json
- git diff --check

## Release setup note
The npm package needs a trusted publisher configured for repository jhipster/react-jhipster and workflow .github/workflows/publish.yml.