### PR TITLE
[codex] Add provenance npm publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,31 @@
+name: Publish Package
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Use Node.js 24
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+          registry-url: https://registry.npmjs.org
+
+      - run: npm ci
+      - run: npm run build
+      - run: npm test
+      - run: npm pack --dry-run
+
+      - name: Publish to npm with provenance
+        run: npm publish --provenance


### PR DESCRIPTION
## Summary

- Add a release-published GitHub Actions workflow for publishing `react-jhipster` to npm.
- Configure Node.js 24, npm registry setup, and OIDC `id-token: write` permissions for npm provenance.
- Run install, build, tests, and `npm pack --dry-run` before `npm publish --provenance`.

Fixes jhipster/generator-jhipster#33522

## Verification

- `npm ci`
- `npm test`
- `npm run build`
- `npm pack --dry-run`
- Parsed `.github/workflows/npm-publish.yml` as YAML
- `npx prettier --check .github/workflows/npm-publish.yml`

## Notes

npm trusted publishing must be configured by maintainers for this repository/workflow on npm before the release job can publish without a token.
